### PR TITLE
Fixed bug while editing products in products list

### DIFF
--- a/backend/seeder.js
+++ b/backend/seeder.js
@@ -8,7 +8,7 @@ const Carousel = require('./models/carouselModel')
 const Category = require('./models/categoryModel')
 const Product = require('./models/productModel')
 const Order = require('./models/orderModel')
-const connectDB = require('./config/db')
+const { connectDB } = require('./config/db')
 
 dotenv.config()
 

--- a/frontend/src/reducers/productReducers.js
+++ b/frontend/src/reducers/productReducers.js
@@ -76,7 +76,7 @@ export const productDetailsReducer = (state = { product: {} }, action) => {
     case PRODUCT_DETAILS_FAIL:
       return { loading: false, error: action.payload }
     case PRODUCT_DETAILS_RESET:
-      return {}
+      return {product: {}}
     default:
       return state
   }


### PR DESCRIPTION
This PR solves #86 

The following is the state of products on /admin/productlist before updating any product:
![image](https://user-images.githubusercontent.com/101405993/194723348-549f1566-b9d5-475e-8833-0a8bcccbad92.png)

After editting any of the products the state of productDetails becomes (note that there is no `product: {}`)  :
![image](https://user-images.githubusercontent.com/101405993/194723444-1d82aabd-3346-4203-867a-d042a938e025.png)

This causes a crash in line 47 of `frontend/src/screens/ProductEditScreen.js`, as product is not defined and we try to access `
product.name` (when trying to edit any product for the second time).
```js
if (!product.name || product._id !== productId) {
    dispatch(listProductDetails(productId))
}
```

Hence, all I did was update the `productDetails` reducer when the `PRODUCT_DETAILS_RESET` action is dispatched.

P.S. The above screenshots were taken using Redux DevTools web extension.