### PR TITLE
Fixed payment and delivery status bug in order page

### DIFF
--- a/backend/controllers/orderControllers.js
+++ b/backend/controllers/orderControllers.js
@@ -113,7 +113,12 @@ const updateOrderToPaid = asyncHandler(async (req, res) => {
 
     order.isPaid = true
     order.paidAt = Date.now()
+    
     const updatedOrder = await order.save()
+    await updatedOrder.populate(
+      'user',
+      'name email',
+    )
     res.json(updatedOrder)
   } else {
     res.status(404)
@@ -148,7 +153,10 @@ const updateOrderToDelivered = asyncHandler(async (req, res) => {
     order.deliveredAt = Date.now()
 
     const updatedOrder = await order.save()
-
+    await updatedOrder.populate(
+      'user',
+      'name email',
+    )
     res.json(updatedOrder)
   } else {
     res.status(404)

--- a/frontend/src/reducers/orderReducers.js
+++ b/frontend/src/reducers/orderReducers.js
@@ -57,6 +57,8 @@ export const orderDetailsReducer = (
         loading: true,
       }
     case ORDER_DETAILS_SUCCESS:
+    case ORDER_PAY_SUCCESS:
+    case ORDER_DELIVER_SUCCESS:
       return {
         loading: false,
         order: action.payload,


### PR DESCRIPTION
@roopeshsn 
This PR resolves #101 .

https://user-images.githubusercontent.com/60524775/196495545-563226d7-0a6a-4aee-b03a-a3ccae79b8ff.mov

Payment status is updated as soon as "Mark as Paid" button is clicked.
Delivery status is updated as soon as "Mark as Delivered" is clicked.
Both actions do not require refreshing the window for the update to render.